### PR TITLE
secrets: add tests and don't log error

### DIFF
--- a/boto3utils/secrets.py
+++ b/boto3utils/secrets.py
@@ -1,11 +1,6 @@
 import base64
 import boto3
 import json
-import logging
-
-from botocore.exceptions import ClientError
-
-logger = logging.getLogger(__name__)
 
 
 def get_secret(secret_name):
@@ -16,23 +11,19 @@ def get_secret(secret_name):
         service_name='secretsmanager'
     )
 
-    # In this sample we only handle the specific exceptions for the 'GetSecretValue' API.
+    # Will throw a botocore.exceptions.ClientError for any of
+    # the specific exceptions for the 'GetSecretValue' API.
     # See https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html
-    # We rethrow the exception by default.
 
-    try:
-        get_secret_value_response = client.get_secret_value(
-            SecretId=secret_name
-        )
-    except ClientError as err:
-        logger.error(f"Error getting secret: {err}")
-        raise(err)
+    get_secret_value_response = client.get_secret_value(
+        SecretId=secret_name
+    )
+
+    # Decrypts secret using the associated KMS CMK.
+    # Depending on whether the secret is a string or binary, one of these fields will be populated.
+    if 'SecretString' in get_secret_value_response:
+        secret = get_secret_value_response['SecretString']
     else:
-        # Decrypts secret using the associated KMS CMK.
-        # Depending on whether the secret is a string or binary, one of these fields will be populated.
-        if 'SecretString' in get_secret_value_response:
-            secret = get_secret_value_response['SecretString']
-        else:
-            secret = base64.b64decode(get_secret_value_response['SecretBinary'])
-            
-        return json.loads(secret)
+        secret = base64.b64decode(get_secret_value_response['SecretBinary'])
+
+    return json.loads(secret)

--- a/test/test_secrets.py
+++ b/test/test_secrets.py
@@ -1,0 +1,41 @@
+import os
+import boto3
+import pytest
+import json
+import base64
+
+# this must be imported before any boto3 module
+from moto import mock_secretsmanager
+
+from boto3utils import secrets
+from botocore.exceptions import ClientError
+
+
+testpath = os.path.dirname(__file__)
+
+
+SECRET_NAME = 'secret'
+SECRET = {'mock_key': 'mock_val'}
+SECRET_STRING = json.dumps(SECRET)
+SECRET_BINARY = base64.b64encode(SECRET_STRING.encode())
+
+
+@mock_secretsmanager
+def test_get_secret_string():
+    boto3.session.Session().client('secretsmanager', region_name='us-west-2').create_secret(Name=SECRET_NAME, SecretString=SECRET_STRING)
+    secret = secrets.get_secret(SECRET_NAME)
+    assert(secret == SECRET)
+
+
+@mock_secretsmanager
+def test_get_secret_undef():
+    with pytest.raises(ClientError):
+        secret = secrets.get_secret(SECRET_NAME)
+
+
+@mock_secretsmanager
+def test_get_secret_binary():
+    boto3.session.Session().client('secretsmanager', region_name='us-west-2').create_secret(Name=SECRET_NAME, SecretBinary=SECRET_BINARY)
+    secret = secrets.get_secret(SECRET_NAME)
+    assert(secret == SECRET)
+    #client.create_secret(Name=SECRET_NAME, SecretBinary=SECRET_BINARY)


### PR DESCRIPTION
The logging in `secrets.py` outputs an error message when an error is encountered, such as when a secret does not exist, which may not be an error condition. As this is a shared lib and not an end application, it seems the logging should be left up to the caller, who can more appropriately determine if the specific `ClientError` raised is in fact an error.

This PR also adds a few test cases for the `get_secrets` function.