### PR TITLE
endpoint url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- boto3utils.s3 object now supports specifying the `endpoint_url` parameter
+  for the underlying boto3 client
+
 ## [v0.4.1] - 2022-11-19
 
 ### Fixed

--- a/boto3utils/s3.py
+++ b/boto3utils/s3.py
@@ -5,7 +5,7 @@ import hmac
 import logging
 import os
 import os.path as op
-from typing import Tuple
+from typing import Tuple, Optional
 
 from botocore.exceptions import ClientError
 from copy import deepcopy
@@ -21,12 +21,17 @@ logger = logging.getLogger(__name__)
 
 
 class s3(object):
-    def __init__(self, session=None, requester_pays=False):
+    def __init__(
+        self,
+        session: boto3.Session = None,
+        requester_pays: bool = False,
+        endpoint_url: Optional[str] = None,
+    ):
         self.requester_pays = requester_pays
         if session is None:
-            self.s3 = boto3.client("s3")
+            self.s3 = boto3.client("s3", endpoint_url=endpoint_url)
         else:
-            self.s3 = session.client("s3")
+            self.s3 = session.client("s3", endpoint_url=endpoint_url)
 
     @classmethod
     def urlparse(cls, url):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,13 @@ def s3_west(aws_credentials):
 
 
 @pytest.fixture
+def s3_custom_endpoint(aws_credentials):
+    os.environ["MOTO_S3_CUSTOM_ENDPOINTS"] = "http://my-s3"
+    with moto.mock_s3():
+        yield boto3.client("s3", endpoint_url="http://my-s3")
+
+
+@pytest.fixture
 def secretsmanager(aws_credentials):
     with moto.mock_secretsmanager():
         yield boto3.client("secretsmanager", region_name="us-east-1")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -188,3 +188,10 @@ def test_latest_inventory():
     #    hours = (datetime.today() - dt).seconds // 3600
     #    assert(hours < 24)
     #    break
+
+
+def test_upload_download_with_custom_endpoint(s3_custom_endpoint):
+    create_test_bucket(s3_custom_endpoint, BUCKET)
+    url = "s3://%s/mytestfile" % BUCKET
+    s3(endpoint_url="http://my-s3").upload(__file__, url, public=True)
+    assert s3(endpoint_url="http://my-s3").exists(url)


### PR DESCRIPTION
**Related Issue(s):** 

n/a


**Description:**

Add support for specifying the endpoint_url when creating a boto3utils.s3 object.


**PR Checklist:**

- [X] Code is formatted
- [X] Tests pass
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)