### PR TITLE
run release workflow with python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
 
       - name: Install release dependencies
         run: |


### PR DESCRIPTION
**Related Issue(s):** #

n/a

**Description:**

release ci failed because python 3.x is 3.12, and there's an issue with `imp` being removed

**PR Checklist:**
n/a